### PR TITLE
check user/group ownership on /etc/shadow

### DIFF
--- a/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Permissions.pm
+++ b/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Permissions.pm
@@ -14,17 +14,34 @@ sub generate_advise {
 }
 
 sub _check_for_unsafe_permissions {
+    return if ($^O ne 'linux');
+
     my ($self) = @_;
 
     my $security_advisor_obj = $self->{'security_advisor_obj'};
 
+    # Warn if /etc/shadow is world readable, world writeable, or world executable
     my $mode = (stat('/etc/shadow'))[2];
-    if ( $mode & 007 ) {
+    if ($mode & 007) {
         $security_advisor_obj->add_advise(
             {
                 'type' => $Cpanel::Security::Advisor::ADVISE_BAD,
                 'text' => ['/etc/shadow has unsafe permissions'],
                 'suggestion' => ['Reset the permissions on /etc/shadow']
+            }
+        );
+    }
+
+    # Warn if /etc/shadow has a user or group which is not root
+    my $uid = (stat('/etc/shadow'))[4];
+    my $gid = (stat('/etc/shadow'))[5];
+
+    if ($uid != 0 or $gid != 0) {
+        $security_advisor_obj->add_advise(
+            {
+                'type' => $Cpanel::Security::Advisor::ADVISE_BAD,
+                'text' => ['/etc/shadow is owned by a user and/or group which is not root'],
+                'suggestion' => ['Reset the ownership permissions on /etc/shadow']
             }
         );
     }


### PR DESCRIPTION
Updated the Permissions.pm assessor to display a warning if /etc/shadow has a user or group which is not root.
