### PR TITLE
Remove unnecessary token logic.

### DIFF
--- a/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor.pm
+++ b/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor.pm
@@ -64,16 +64,7 @@ sub add_advise {
     my ( $self, $advise ) = @_;
 
     my $function = ( split( m{::}, ( caller(1) )[3] ) )[-1];
-    my $token = $self->security_token();
-
-    if ( $advise->{suggestion} && ref $advise->{suggestion} eq 'ARRAY' ) {
-        $advise->{suggestion} = [ map { s/~token~/$token/ig; $_ } @{ $advise->{suggestion} } ];
-    }
     push @{ $self->{'advise'}->{ ( caller(1) )[0] }->{$function} }, $advise;
-}
-
-sub security_token {
-    return ( $ENV{'cp_security_token'} || '' );
 }
 
 1;

--- a/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Apache.pm
+++ b/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Apache.pm
@@ -41,9 +41,9 @@ sub _check_for_apache_chroot {
                 'text'       => ['Apache vhosts are not chroot()ed.'],
                 'suggestion' => [
                     'Enable “Jail Apache” in the “[output,url,_1,Tweak Settings,_4,_5]” area, and change users to jailshell in the “[output,url,_2,Manage Shell Access,_4,_5]” area.  Consider a more robust solution by using “[output,url,_3,CageFS on CloudLinux,_4,_5]”',
-                    $security_advisor_obj->security_token() . "/scripts2/tweaksettings?find=jailapache",
-                    $security_advisor_obj->security_token() . "/scripts2/manageshells",
-                    "http://cpanel.net/cpanel-whm/cloudlinux/",
+                    '../scripts2/tweaksettings?find=jailapache',
+                    '../scripts2/manageshells',
+                    'http://cpanel.net/cpanel-whm/cloudlinux/',
                     'target',
                     '_blank'
                 ],

--- a/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Brute.pm
+++ b/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Brute.pm
@@ -46,8 +46,7 @@ sub _check_for_brute_force_protection {
                 'text'       => ['No brute force protection detected'],
                 'suggestion' => [
                     'Enable cPHulk Brute Force Protection in the “[output,url,_1,cPHulk Brute Force Protection,_2,_3]” area.',
-                    $security_advisor_obj->security_token()
-                      . "/cgi/tweakcphulk.cgi",
+                    '../cgi/tweakcphulk.cgi',
                     'target',
                     '_blank'
 

--- a/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Frontpage.pm
+++ b/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Frontpage.pm
@@ -27,7 +27,7 @@ sub _is_frontpage_installed {
                 'text'       => ['Frontpage is installed'],
                 'suggestion' => [
                     'Rebuild using “[output,url,_1,EasyApache,_2,_3]” without Frontpage selected, then uninstall the Frontpage RPM (rpm -e frontpage)',
-                    '~token~/cgi/easyapache.pl?action=_pre_cpanel_sync_screen', 'target', '_blank',
+                    '../cgi/easyapache.pl?action=_pre_cpanel_sync_screen', 'target', '_blank',
                 ],
             }
         );

--- a/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Jail.pm
+++ b/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Jail.pm
@@ -29,7 +29,7 @@ sub _check_for_unjailed_users {
                     'text'       => ['Jailshell is mounting /usr/bin suid, which allows escaping the jail via crontab.'],
                     'suggestion' => [
                         'Disable “Jailed /usr/bin mounted suid" in the “[output,url,_1,Tweak Settings,_2,_3]” area',
-                        $security_advisor_obj->security_token() . "/scripts2/tweaksettings?find=jailmountusrbinsuid",
+                        "../scripts2/tweaksettings?find=jailmountusrbinsuid",
                         'target',
                         '_blank'
                     ],
@@ -50,7 +50,7 @@ sub _check_for_unjailed_users {
                     'text'       => [ 'Users running outside of the jail: [list_and,_1].', \@users_without_jail ],
                     'suggestion' => [
                         'Change these users to jailshell in the “[output,url,_1,Manage Shell Access,_2,_3]” area.',
-                        $security_advisor_obj->security_token() . "/scripts2/manageshells",
+                        '../scripts2/manageshells',
                         'target',
                         '_blank'
 

--- a/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Mysql.pm
+++ b/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Mysql.pm
@@ -21,7 +21,7 @@ sub generate_advise {
             'text'       => ['Cannot connect to MySQL server.'],
             'suggestion' => [
                 'Enable MySQL database service',
-                "~token~/scripts/srvmng",
+                '../scripts/srvmng',
                 'target',
                 '_blank'
             ],

--- a/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Passwords.pm
+++ b/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Passwords.pm
@@ -25,7 +25,7 @@ sub _check_for_low_pwstrength {
                 'text'       => ['Trivially weak passwords are permitted.'],
                 'suggestion' => [
                     'Configure Password Strength requirements in the “[output,url,_1,Password Strength Configuration,_2,_3]” area',
-                    $security_advisor_obj->security_token() . "/scripts/minpwstrength",
+                    '../scripts/minpwstrength',
                     'target',
                     '_blank'
                 ],
@@ -40,7 +40,7 @@ sub _check_for_low_pwstrength {
                 'text'       => ['Password strength requirements are low.'],
                 'suggestion' => [
                     'Configure a Default Password Strength of at least 50 in the “[output,url,_1,Password Strength Configuration,_2,_3]” area',
-                    $security_advisor_obj->security_token() . "/scripts/minpwstrength",
+                    '../scripts/minpwstrength',
                     'target',
                     '_blank'
                 ],
@@ -55,7 +55,7 @@ sub _check_for_low_pwstrength {
                 'text'       => ['Password strength requirements are moderate.'],
                 'suggestion' => [
                     'Configure a Default Password Strength of at least 65 in the “[output,url,_1,Password Strength Configuration,_2,_3]” area',
-                    $security_advisor_obj->security_token() . "/scripts/minpwstrength",
+                    '../scripts/minpwstrength',
                     'target',
                     '_blank'
                 ],

--- a/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/SSH.pm
+++ b/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/SSH.pm
@@ -24,7 +24,7 @@ sub _check_for_ssh_settings {
             'text'       => ['SSH password authentication is enabled.'],
             'suggestion' => [
                 'Disable SSH password authentication in the “[output,url,_1,SSH Password Authorization Tweak,_2,_3]” area',
-                "~token~/scripts2/tweaksshauth",
+                '../scripts2/tweaksshauth',
                 'target',
                 '_blank'
             ],
@@ -42,7 +42,7 @@ sub _check_for_ssh_settings {
             'text'       => ['SSH direct root logins are permitted.'],
             'suggestion' => [
                 'Manually edit /etc/ssh/sshd_config and change PermitRootLogin to “no”, then restart SSH in the “[output,url,_1,Restart SSH,_2,_3]” area',
-                "~token~/scripts/ressshd",
+                '../scripts/ressshd',
                 'target',
                 '_blank'
             ],

--- a/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Spam.pm
+++ b/pkg/var/cpanel/addons/securityadvisor/perl/Cpanel/Security/Advisor/Assessors/Spam.pm
@@ -33,7 +33,7 @@ sub _check_for_nobody_tracking {
                 'text'       => ['The psuedo-user “nobody” is permitted to send email.'],
                 'suggestion' => [
                     'Enable “Prevent "nobody" from sending mail” in the “[output,url,_1,Tweak Settings,_2,_3]” area',
-                    $security_advisor_obj->security_token() . "/scripts2/tweaksettings?find=nobodyspam",
+                    '../scripts2/tweaksettings?find=nobodyspam',
                     'target',
                     '_blank'
                 ],
@@ -57,7 +57,7 @@ sub _check_for_nobody_tracking {
                 'text'       => ['Outbound SMTP connections are unrestricted.'],
                 'suggestion' => [
                     'Enable SMTP Restrictions in the “[output,url,_1,SMTP Restrictions,_2,_3]” area',
-                    $security_advisor_obj->security_token() . "/scripts2/smtpmailgidonly",
+                    '../scripts2/smtpmailgidonly',
                     'target',
                     '_blank'
                 ],
@@ -82,7 +82,7 @@ sub _check_for_nobody_tracking {
                 'text'       => ['Apache is not being queried to determine the actual sender when mail originates from the “nobody” psuedo-user.'],
                 'suggestion' => [
                     'Enable “Query Apache server status to determine the sender of email sent from processes running as nobody” in the “[output,url,_1,Exim Configuration Manager,_2,_3]” area\'s “Basic Editor”',
-                    $security_advisor_obj->security_token() . "/scripts2/displayeximconfforedit",
+                    '../scripts2/displayeximconfforedit',
                     'target',
                     '_blank'
                 ],


### PR DESCRIPTION
Security tokens can be handled more elegantly with relative URLs.
