### PR TITLE
Improved use of localization (and explicitly use Cpanel::Template).

### DIFF
--- a/pkg/cgi/addon_securityadvisor.cgi
+++ b/pkg/cgi/addon_securityadvisor.cgi
@@ -37,16 +37,18 @@ package cgi::addon_securityadvisor;
 BEGIN {
     unshift @INC, '/var/cpanel/addons/securityadvisor/perl', '/usr/local/cpanel';
 
+    # can go away after rt 85588 is in place
     require Cpanel::Locale;
-
-    *Cpanel::Locale::maketext_ref = sub {
-        return shift->maketext( ref $_[0] ? @{ $_[0] } : @_ );
+    no warnings 'once';
+    *Cpanel::Locale::makevar = sub {
+        return shift->maketext( ref $_[0] ? @{ $_[0] } : @_ );    ## no extract maketext
     };
 }
 
 use Whostmgr::ACLS          ();
 use Whostmgr::HTMLInterface ();
 use Cpanel::Form            ();
+use Cpanel::Template        ();
 
 # from /var/cpanel/addons/securityadvisor/perl
 use Cpanel::Security::Advisor ();

--- a/pkg/templates/main.tmpl
+++ b/pkg/templates/main.tmpl
@@ -32,7 +32,7 @@ var notices = [];
                         level:  [% item.type %] == 8 ? "error" : [% item.type %] == 4 ? "warn" : [% item.type %] == 2 ? "info" : "success",
                         type:  [% item.type %],
                         container: DOM.get('securityadvise'),
-                        content: [% locale.maketext_ref(item.text).json %] + "<blockquote>" + [% locale.maketext_ref(item.suggestion).json %] + "</blockquote>"
+                        content: [% locale.makevar(item.text).json %] + "<blockquote>" + [% locale.makevar(item.suggestion).json %] + "</blockquote>"
                 } );
           </script>
       [% END %]


### PR DESCRIPTION
- note rt that make the override moot (should we do apply that now and ditch the override?)
- use makevar() in the template to avoid the need to do what rt describes and to avoid needing a funny method

of note: the text is not marked as translatable so parsers will miss it (this is true w/ out this chnage, with this change, or with the evaltt approache listed at the rt)
