### PR TITLE
Small fix for Kernel.pm

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -42,15 +42,15 @@ sub _check_for_kernel_version {
     my $installed_rpms = $self->get_installed_rpms();
     my $available_rpms = $self->get_available_rpms();
 
-	my $running_kernelversion = ( Cpanel::OSSys::uname() )[2];
-	$running_kernelversion =~ s/\.[a-z][0-9_]+//;
+    my $running_kernelversion = ( Cpanel::OSSys::uname() )[2];
+    $running_kernelversion =~ s/\.[a-z][0-9_]+//;
     my $running_kernelversion_without_release = ( split( m/-/, $running_kernelversion ) )[0];
 
     my $current_kernelversion = $installed_rpms->{'kernel'};
 
     my $latest_kernelversion = $available_rpms->{'kernel'};
     my $latest_kernelversion_without_release = ( split( m/-/, $latest_kernelversion ) )[0];
-	
+
     if ( length $current_kernelversion && length $latest_kernelversion ) {
         if ( $running_kernelversion_without_release ne $latest_kernelversion_without_release ) {
             $self->add_info_advice( 'text' => [ 'Custom kernel version cannot be checked to see if it is up to date: ' . $running_kernelversion ] );


### PR DESCRIPTION
Noticed an issue on my machine with the kernel checks. It claimed that I wasn't running the latest kernel, but that it was installed and recommended a reboot. It didn't go away after the reboot and I found it was due to ".x86_64" at the end of the string. I added 1 line that fixes that and doesn't seem to cause an issue. Please ignore the two test commits, I was having a small issue with git.

![screen shot 2013-05-30 at 6 42 14 pm](https://f.cloud.github.com/assets/3308274/588392/b43ed9e4-c982-11e2-80ae-710aa61fa5b5.png)
