### PR TITLE
Regex for Kernel.pm

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -43,15 +43,15 @@ sub _check_for_kernel_version {
     my $available_rpms = $self->get_available_rpms();
 
     my $running_kernelversion = ( Cpanel::OSSys::uname() )[2];
-    $running_kernelversion =~ s/(?:\.x86_64|\.i.86)$//;    #strip arch
+    $running_kernelversion =~ s/.(?:x86_64|i.86)$//;    #strip arch
     my $running_kernelversion_without_release = ( split( m/-/, $running_kernelversion ) )[0];
 
     my $current_kernelversion = $installed_rpms->{'kernel'};
-    $current_kernelversion =~ s/(?:\.x86_64|\.i.86)$//;    #strip arch
+    $current_kernelversion =~ s/.(?:x86_64|i.86)$//;    #strip arch
 
     my $latest_kernelversion = $available_rpms->{'kernel'};
     my $latest_kernelversion_without_release = ( split( m/-/, $latest_kernelversion ) )[0];
-    $latest_kernelversion =~ s/(?:\.x86_64|\.i.86)$//;     #strip arch
+    $latest_kernelversion =~ s/.(?:x86_64|i.86)$//;     #strip arch
 
     if ( length $current_kernelversion && length $latest_kernelversion ) {
         if ( $running_kernelversion_without_release ne $latest_kernelversion_without_release ) {


### PR DESCRIPTION
Didn't notice this last night, however it's not capturing the period right before the arch, so it still fails. This should fix it (I opted for . instead of . to match exactly, feel free to change that if you want).
![screen shot 2013-05-31 at 12 41 38 pm](https://f.cloud.github.com/assets/3308274/592375/8f4e42cc-ca19-11e2-950f-02eda214f06e.png)
