### PR TITLE
Issue 18: Suggestions: EasyApache - Tomcat 5.5 is installed

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Tomcat.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Tomcat.pm
@@ -38,7 +38,7 @@ sub _is_tomcat5_installed {
     my ($self) = @_;
     my $security_advisor_obj = $self->{'security_advisor_obj'};
 
-    if ( -s '/usr/local/jakarta/tomcat' ) {
+    if ( -l '/usr/local/jakarta/tomcat' ) {
         $security_advisor_obj->add_advice(
             {
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,


### PR DESCRIPTION
Check if /usr/local/jakarta/tomcat exists and is a symlink.
If so, they've installed Tomcat 5.5.x - we don't really care
which point release, since they're all EOL.
