### PR TITLE
Issue 03: Correct typo: psuedo vs pseudo in Spam.pm

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Spam.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Spam.pm
@@ -45,7 +45,7 @@ sub _check_for_nobody_tracking {
         $security_advisor_obj->add_advice(
             {
                 'type' => $Cpanel::Security::Advisor::ADVISE_GOOD,
-                'text' => ['The psuedo-user “nobody” is not permitted to send email.'],
+                'text' => ['The pseudo-user “nobody” is not permitted to send email.'],
             }
         );
     }
@@ -53,7 +53,7 @@ sub _check_for_nobody_tracking {
         $security_advisor_obj->add_advice(
             {
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
-                'text'       => ['The psuedo-user “nobody” is permitted to send email.'],
+                'text'       => ['The pseudo-user “nobody” is permitted to send email.'],
                 'suggestion' => [
                     'Enable “Prevent "nobody" from sending mail” in the “[output,url,_1,Tweak Settings,_2,_3]” area',
                     $self->base_path('scripts2/tweaksettings?find=nobodyspam'),
@@ -110,7 +110,7 @@ sub _check_for_nobody_tracking {
         $security_advisor_obj->add_advice(
             {
                 'type'       => $Cpanel::Security::Advisor::ADVISE_BAD,
-                'text'       => ['Apache is not being queried to determine the actual sender when mail originates from the “nobody” psuedo-user.'],
+                'text'       => ['Apache is not being queried to determine the actual sender when mail originates from the “nobody” pseudo-user.'],
                 'suggestion' => [
                     (
                         $Cpanel::Version::MAJORVERSION > 11.35


### PR DESCRIPTION
Part 2/2 - rewrite of pull request https://github.com/bdraco/addon_securityadvisor/pull/3 - fix typo in Spam.pm. If this change + the changes in https://github.com/bdraco/addon_securityadvisor/pull/52 are committed, issue #3 can be closed.
