### PR TITLE
Don't run kernel check on openvz

### DIFF
--- a/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
+++ b/pkg/Cpanel/Security/Advisor/Assessors/Kernel.pm
@@ -62,6 +62,9 @@ sub _check_for_kernel_version {
         if ( $running_kernelversion_without_release ne $latest_kernelversion_without_release ) {
             $self->add_info_advice( 'text' => [ 'Custom kernel version cannot be checked to see if it is up to date: ' . $running_kernelversion ] );
         }
+        elsif ( `cat /var/cpanel/envtype` == "virtuozzo") { # Dont't run on openvz, as it is pointless. They cannot update their Kernel
+            $self->add_info_advice( 'text' => [ 'Kernel updates not supported on this virtualization platform: [_1]', `cat /var/cpanel/envtype` ] );
+        }
         elsif ( $current_kernelversion ne $latest_kernelversion ) {
             $self->add_bad_advice(
                 'text'       => ["Current kernel version is out of date. current: $current_kernelversion, expected: $latest_kernelversion"],


### PR DESCRIPTION
This check is moot on openvz, as the host node controls the kernel.

I've also seen it create some weird errors such as (verbatim):
A newer kernel is installed, however the system has not been rebooted. running kernel: 2.6.32-042stab078.28, most recent installed kernel:

The "newer" kernel is blank as on openvz there may not be any kernel packages installed.